### PR TITLE
Add checksum type to targets/primer.rb.

### DIFF
--- a/targets/primer.rb
+++ b/targets/primer.rb
@@ -3,6 +3,7 @@
 def target(vconfig, _custom)
   vconfig.vm.define :primer, autostart: false do |target|
     target.vm.box = 'Sliim/vulnhub-primer'
+    target.vm.box_download_checksum_type = 'sha256'
     target.vm.box_download_checksum = '342bb82ebce63a819575ba2f2b7a4a2d'\
                                       '4fa53c70bd377076cdffbf9b3a0788f4'
 


### PR DESCRIPTION
- Error occurs if not present on Vagrant 1.9.1.