### PR TITLE
 Fix the "ArgumentError while executing berks vendor"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf'
+gem 'ffi-libarchive'
 
 group :checkstyle do
   gem 'rubocop'


### PR DESCRIPTION
This fix is to correct the ArgumentError "\x80\x00\x00\x00\e\xA3V\xC0" is not an octal string that gets presented to the user while executing "bundle exec berks vendor". 

For more details see https://github.com/Sliim/pentest-env/issues/49